### PR TITLE
Can return binned_counts with desired bin unit (keV vs angs)

### DIFF
--- a/notebooks/Background_Spectrum.ipynb
+++ b/notebooks/Background_Spectrum.ipynb
@@ -246,7 +246,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,

--- a/notebooks/Binned_Spectrum.ipynb
+++ b/notebooks/Binned_Spectrum.ipynb
@@ -301,7 +301,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,

--- a/notebooks/Stacked_Spectrum.ipynb
+++ b/notebooks/Stacked_Spectrum.ipynb
@@ -153,7 +153,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,

--- a/notebooks/load_data_Spectrum1D.ipynb
+++ b/notebooks/load_data_Spectrum1D.ipynb
@@ -1,0 +1,209 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Basic test of load functionality"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "import clarsach\n",
+    "import pyxsis\n",
+    "\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "DATA_DIR = os.environ['HOME'] + \"/dev/pyxsis/testdata/\"\n",
+    "mrk_dir  = DATA_DIR + \"tgcat/obs_15484_tgid_4689/\"\n",
+    "mrk_heg1_file = mrk_dir + \"heg_1.pha\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load the dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:root:No spectral axis units given, assuming Angstrom\n",
+      "WARNING:root:GWCS does not store rest frequency information. Please define the rest value explicitly in the `Spectrum1D` object.\n",
+      "WARNING:root:GWCS does not store rest wavelength information. Please define the rest value explicitly in the `Spectrum1D` object.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Spectral unit is Angstrom\n",
+      "loading rmf file: /Users/lia/dev/pyxsis/testdata/tgcat/obs_15484_tgid_4689/heg_1.rmf\n",
+      "loading arf file: /Users/lia/dev/pyxsis/testdata/tgcat/obs_15484_tgid_4689/heg_1.arf\n",
+      "Warning: ARF units and pha file units are not the same!!!\n",
+      "Warning: RMF units and pha file units are not the same!!!\n"
+     ]
+    }
+   ],
+   "source": [
+    "mrk421 = pyxsis.XSpectrum(mrk_heg1_file, telescope='HETG')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'from astropy.io import fits\\ntest = fits.open(\"/Users/lia/dev/pyxsis/testdata/tgcat/obs_15484_tgid_4689/heg_1.arf\")\\ntest.info()'"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "'''from astropy.io import fits\n",
+    "test = fits.open(\"/Users/lia/dev/pyxsis/testdata/tgcat/obs_15484_tgid_4689/heg_1.arf\")\n",
+    "test.info()'''"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Text(0.5,0,'angstrom')"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXQAAAEKCAYAAAACS67iAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMS4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvNQv5yAAAIABJREFUeJzt3Xl4VOX5N/DvTUjYgkAkLLIFFAURBY2CCypg69ZWu1ntT0v7aqmtvNbr53v1R7UKb7XV1qpoa60oFlqlvrZuSCoqCAKVLUSWhEWQhCUJJCEbISHLzP3+MSfDJJl9ziznnO/nurgyc+bMOXcOk2+ePOc5zxFVBRERWV+3ZBdARETmYKATEdkEA52IyCYY6ERENsFAJyKyCQY6EZFNMNCJiGyCgU5EZBMMdCIim+geagUR6QlgLYAexvr/UtV5IjIawBsAsgAUALhLVVuCbWvgwIGak5MTc9FERE6ydevWKlXNDrVeyEAH0Axghqo2iEg6gPUi8gGA/wbwrKq+ISJ/AXA3gBeDbSgnJwf5+flh7JKIiNqJyMFw1gvZ5aIeDcbTdOOfApgB4F/G8iUAbo2iTiIiMklYfegikiYi2wBUAPgYwJcAalW1zVjlCIBhAd47W0TyRSS/srLSjJqJiMiPsAJdVV2qOgnAcACXARjvb7UA712oqrmqmpudHbILiIiIohTRKBdVrQWwBsBUAP1FpL0PfjiAMnNLIyKiSIQMdBHJFpH+xuNeAK4DsBvAagDfMVabBeC9eBVJREShhTPKZSiAJSKSBs8vgDdVdbmI7ALwhog8DuBzAIviWCcREYUQMtBVdQeAyX6WH4CnP52IiFIArxR1KLdb8eaWw2hzub3LKk80Y0Xh0SRWRUSxYKA71Jv5h/GLt3Zg0fpi77K7Fm3Cva9tRWNLW5B3ElGqYqA7VE1jKwCguvH0bA2HqxsBAG7eN5zIkhjoREQ2wUAnIrIJBjp5saeFyNoY6NSFJLsAIooKA93hSmua8PsVe6DK9jmR1YVzpSjZ2PId5QCAWyb5nSyTiCyELXQCACh70Iksj4FOXux1IbI2Bjp1ITwrSmRJDHSHYmgT2Q8Dnbpg1wuRNTHQCQBQUd+MplYXAODPa/YnuRoiigYDnQAAecbwRQB4YfWXSayEiKLFQHeozt0qHLZIZH0MdALAfnMiO2CgEwBOzEVkBwx0IiKbYKATEdkEA90BXli9Hzlz89DS5g64zr+2HunwPGduHgoO1XgfP/zOzrjWSESxY6A7wF/WeIYhnmpzeZeFc6Xo6j0V3sevbzpkel1EZC4GOhGRTTDQKSBO90JkLSEDXURGiMhqEdktIkUi8nNj+XwRKRWRbca/m+JfLkWDQxKJnCGcOxa1AXhQVQtEpC+ArSLysfHas6r6h/iVR2Zii5vI3kK20FW1XFULjMcnAOwGwPuVpbhTrS7sr2hAQ3Nb1NtYtacCTS2ukOsdrTuFNlfgETRElBgR3VNURHIATAawCcCVAOaIyA8A5MPTiq8xu0CKzqxXN2NTcTV6pachrVt0bfOisnqMf3RF0HXqmlox9YlVuHPqSDx+68So9kNE5gj7pKiIZAJ4C8ADqloP4EUAZwOYBKAcwNMB3jdbRPJFJL+ystKEkikcm4qrAcA7JW68nDjVCgBYvYf/t0TJFlagi0g6PGH+uqq+DQCqekxVXarqBvAygMv8vVdVF6pqrqrmZmdnm1U3RUATMPNWIvZBRMGFM8pFACwCsFtVn/FZPtRntW8CKDS/PDKTxOG+c/HYJhFFJ5w+9CsB3AVgp4hsM5Y9BOAOEZkEz6i4EgA/iUuFlNLYMidKHSEDXVXXw/+It3+bXw7FE8OXyN54pSjFhF0uRKmDge4g8Qxftv2Jko+BTkRkEwx0IiKbYKA7QDy7Q9iDTpQ6GOgOwvAlsjcGOhGRTTDQbeiLYyc6PG8MY8bEWLW63PhN3i4sWPkFTrW68MdV+4Lew5SIzBfRbItkDV99dm3C91nV0IKX1xUDANbtq8LWgzXI7NkdP7pydMJrIXIqttAdyqz+dH9D2+uaPDMwnmplC50okRjoDsKLOonsjYFORGQTDHQH8Z2bi5fqE9kPA52IyCYY6A7i24fuTsBUum5VzFlagMLSOu+ympMt+OFfN+N4Q3Pc90/kNAx0h6puaIn7PkqqTmL5jnLc/4/Pvcv+vvEg1uytxOLPSuK+fyKnYaBTTMTPAEjeSIMoORjoZLpgcc6sJ4ofBrqD+LamzRqT7m874WyaQ+KJzMdAp5j4a3EHuzOScsAkUdww0B0q6fcCTfb+iWyIk3PFoLC0Dl/743p88uA1GJOdmexyAABLQoweuW9pAfJ2lJu2v8M1jV2W7a9o8Lvu5uJqLFi5z7R9E1FHbKHH4N3PSwEAq3ZXJLmS0+YtKwr6uplhDgBr9ob+3ts7WV7fdNC7jO1zIvMx0Clu2KtClFgMdAdJpROSDHsi84UMdBEZISKrRWS3iBSJyM+N5Vki8rGI7DO+Doh/uZRq/F1Y1K59BAyzmygxwmmhtwF4UFXHA5gK4D4ROR/AXACrVHUsgFXGc3KYaFvawX4REFF0Qga6qparaoHx+ASA3QCGAbgFwBJjtSUAbo1XkWSOWK/SdLlPb+BUqwttruB3JGo1Xm9uc/u9v+jJ5rbYCiKiDiLqQxeRHACTAWwCMFhVywFP6AMYZHZxZK4nP9gT0/tvX7jB+3jcIyvwvYUbg67/7rYyAEBpbRNmPL2mw2s7S+swYd6H+GCnuaNuiJws7EAXkUwAbwF4QFXrI3jfbBHJF5H8ysrKaGokk/x948HQKwWxpaSmw/OtB2vC7jg5UtPU4fnO0loAwNp9VTHVRESnhRXoIpIOT5i/rqpvG4uPichQ4/WhAPwOSFbVhaqaq6q52dnZZtRMqSTKTvTTfeipM/KGyOrCGeUiABYB2K2qz/i8tAzALOPxLADvmV+eNaTScMCEi7Jjvv33AGdfJDJPOJf+XwngLgA7RWSbsewhAE8CeFNE7gZwCMB341Ni6uJY6ujb1zx0ROYLGeiquh6Bf/5mmluOtbB1Gb32ycF4DInMwytFTbD9cF3olWzkVKvL+7i0tinImh1tO1wb1fuIKDwMdBPk7SzHegeN1njwn9u9j98uKA37fQePd52Z0dHnH4hMxkA3SWlt17Cyq62dhi/Ggl0uROZhoFPE3ExhopTEQKeIMc6JUhMDnSKmJrbQ+cuByDwMdJNw9kAiSjYGegibDhxHUZn/YYlOvLBo55E6U09k+tvW8h1lqDhxyrydEDkEAz2E7y3ciJufX5/sMlLG1/+0Pq4nRU+casWcpZ/jB4s2x20fRHbFQKeImRnnncehu41p08t44RFRxBjoFDFTG+g8K0pkGga6WRzUn27mKJeA+4j7Hojsh4Eegw655qAEiuu36qBfjERmY6BTxEwd5WLepogcj4EegKriDx/u9T4/3tCMee8V+r3ZcTCL1hdjc3G12eV1sb+iAZN//VHc9wMADSbe3HlnafCZKltdbsxfVoSqhmbT9klkVwz0AGoaW/Gn1fu9zx9bvgtLNhzEiqKj/t8QoKvgseW7cNtLG/y/aKI7X9mEmsbWuO/HbPsrGoK+vnLXMSz+rATzlhUlqCIi62KgB9D5xJ9L/S9PFa2uyP5ysAp3ih93olTCQI+BE68UTRjmN1HEGOhhYgsxMfhLkih6DPQAJECyBFwez2KIiMLAQKeUwj+EiKLXPdkFpJo9R+tx5yubsfTHUzosbx+uuGZvBaaOzsJNz6/DBcP6BdzO+EdWoMnnZspjfpmHe6aNQVOLZ9ljt14Qc62/X7EHZbVNWHD75Ji3RUTWx0Dv5JV1xahqaMYneyo6LC+r80wW9XZBKSaPHICqhhas2VsZcDu+YQ54RmssXHvA+9yMQP/zmi8BAAtun2ybc4ide7R4E2mi8LHLJYDOfeKhRgUG6lsnIkoUBnqYQo1y4SgYc7UfTd4Jiih8IQNdRF4VkQoRKfRZNl9ESkVkm/HvpviWmTiBctnlTu3AtssvFMY3UfTCaaEvBnCDn+XPquok49+/zS0r+Tr3oKR6oNsFjzJR9EIGuqquBRD/2aVSnMsmLWAisq9YRrnMEZEfAMgH8KCq1phUU0o6eLzR+/iRdwu7vN5+UjRnbl7CarKjo3Wem0ObOaMjkVNEe1L0RQBnA5gEoBzA04FWFJHZIpIvIvmVlYGH+REBwN6jJ5JdApFlRRXoqnpMVV2q6gbwMoDLgqy7UFVzVTU3Ozs72jrJoTgOnSh8UQW6iAz1efpNAF37ICyqPUCsNlyOsUdEIfvQReQfAK4FMFBEjgCYB+BaEZkET46UAPhJHGtMikivE7JW/Keuzr+YrPaLlSiZQga6qt7hZ/GiONSSUjioJTnsMp6eKBkcf6VoeV0TTvnOu2LkycmWyEZZuFVRcCj8gT6bi6tRF8Yt4w5XN4Y1Br7Wgrefa7elpBrHec9Qopg5PtAvf+IT/Oz1gi7LF6zcF9F2nv9kH77158/CXv+2lzbgohA3dT54/CSm/X41Fqz8Iuh6y7aXhb3fVPTdv2zAJY+vBMA5cYhi4fhAB9BxZsUo8+RwdZM5xfg4Vu9ptW48cDzoeoWldabvm4ish4HemQW7cO3cqOWwRaLwMdBtoJuNEj3QSVGOdiEKjYFuA2k2CnQiih4D3Qa6OSDP2fVCFBoD3bCisBxut+Lzw7XJLiViz3+yP9klmOL7L2/E2i+qOixjVwtR+HhPUcO9rxXgsVsvQHHVyWSX4liffRl8NA8RBefoFnrnE3AV9aeSVIl/ibpq8s6pIwEAs68ek5D9EVF8ODrQiYjsxNGB3rkBnGrTiPCqSZ4MJYqEowOdPNp/kaXyrw+eHCUKjYGewjjzIBFFwtGjXDrHZYdZF5Nk/b4qtLhccLuBwrLTc7RsLvbMSHikpglfu2gohvbrlcQqE6OqoRnPGZOktXe91DW2YsmGEsyZfg66dRqA337sZowb3GVbb2w+hLGDM7F+33HMmXEO0pwweJ8cx9GB3tkr64uTXQLuXLTJ7/LbXtrgffzutlLk3T/NtH3efdVorNtXhesvGIKX1h4wbbuxyjVmYPQ1//0ivPN5KSacdQZmju8Y3O3HruTJm7u8b+7bO72PzxuSiRsuGNplHSKrc3SXi1W7NE42RzZXeyhjsjOx9hfTkZ3Zw9TtxkP7997qiv7/Lpb3EqUyRwc6EZGdMNAtiMMZicgfRwc6//C2jq7DFvm/R9SZowOdrId/nBAF5uhRLlY5J1pxousNlP+2oSThdSRT3s5y5M3N8/taUVkdnvpwb9jbssh/O1HEHB3oVnHweGOXZY++V2TKtm/LHW7KdpLpf97agcLS+mSXQZR07HJxuNxRWckuIUrR972w14bsytGBbtWJnxhIgG/HiVW6zojiLWSgi8irIlIhIoU+y7JE5GMR2Wd8HRDfMilerPpLLRbO+47JKcJpoS8GcEOnZXMBrFLVsQBWGc8thy07IrKTkIGuqmsBVHdafAuAJcbjJQBuNbkuCsbEPhc7/FKL9HtglxXZVbSjXAarajkAqGq5iAwysaa4yjGGvh347U3YcMCa97A8UMn7nt77WgFmjBuE+qZW7CqPbITLgpVf4OsXnRWnyoiSJ+7DFkVkNoDZADBy5Mh47y5sLS43lm46lOwyks7KDfRP9lRE9b4v+QuRbCraUS7HRGQoABhfA/5kqepCVc1V1dzs7Owod0dERKFEG+jLAMwyHs8C8J455SSOqj36j2PFY0BkH+EMW/wHgA0AzhORIyJyN4AnAXxFRPYB+Irx3FI8w/WYZkRkHyH70FX1jgAvzTS5FiIiioHtrxR1uRX1p1q7LK880Yz6U+be+ScaLW1uNLYkrw4nXFjU6nKHtd6pVlfI+8qebG4Le3tEiWb7QH88bxcunP8Rmlo6/qBe89QabC7uPLw+8a55ajXOf/TDZJdha2Mf/iCs9S6c/xEmzAv+fzFh3of4/ssbzSiLyHS2D/T3tpUBAE4msRUcTHndqaTuv+uNIzzen3MV3r3vygRXk1wtLjdc7tB/sWwpqUlANUSRs/30ue1xxdEc4Rs+oBcmDu+X7DKIKEK2b6HzDjdE5BS2D/R2Tjj5R0TO5oBAN5rozHMisjkHBPppuyOcxCnR9hxN7fqsotLnHqzH6v2fdN5f0eB9fOh4I8pqm7zP9x49gYPHT+JoFCesVTUlRk+RMzkq0G98bl2ySwjqhgWJr8/3HEP/3ukAgG9fbO37jF755Cfex1N+u8rvOtc986n38dVPrcYVPu+5fsFaXPPUGkx9wv97g3lt40Hc9tIGfFh0NOL3EsXK9oEuDuxx2fLwdVG9r2/PdOx9/AY8cN1YkytKrJYkXvjTPpNjaU1TiDWJzOeYYYtOckav6P9be3RPM7ESIkok27fQ2zlpHHqgi4WIyN5sH+inu1wclOgRYPQT2Yf9A92BkRXJxVS88IrIPmwf6EeNYWur91QmuRJKJLdb8eh7hUHXmbO0ADUnW4KuU2oMZ1xReBTjH1nR5fX5y4rw3rbS6AslMpHtA73dQ+/sTHYJCZMmgsFn9EC3MFrf08aac1vAK88505TtmGX5znL8bcPB4OvsKMfkxz4Ous6tL/wHAHDva1vR1Glq3cLSOiz+rAQ/f2NbbMUSmcQxge4k3boJNj10HQ48cTNmXT4q6Lpn9e8V9X4eu2WC9/Hr90zFTROHRL0tszWYNNe970VKnYWaO50o0RjoFLXOp5lT6XwFT4KTEzHQyZacNEyVqB0DncyTOg10IkdioJNpUinP2UAnJ7JloP+/LYeworAcz6/al+xSwuYO49ZnFL6i0jrTtpUzN6/Lsgff3I7v/GWD9/n8ZUUdXv/8cK2lPn9kD7acy+V/3rLeEMWisvhMnXv/zLHYfqQOWX0y0Ldnd+89VuNhUN+eYa97Vr+eKIvj/VTf2HI4btsGgLcKjnR4vvizEsz/xulRP+9v9xzn+2dae6IzshZbttCtyB3jWbyX7rrE7/IzM3vg3fuuxKs/vBTP3T456u1PGZ0Vcp1Irjo9M7NH1LUQkX8M9BSR6h0uZtfHYYVE5oupy0VESgCcAOAC0KaquWYU5URqwXF2FiyZyNbM6EOfrqpVJmyHYhD3ESZhhHcqjXIhciJ2uaQIpzV22bonMl+sga4APhKRrSIy24yCnOpbf/4s2SUEF0bz2+kZnTM3D4s/K+mwbOOB4xj/yAocrm7E917agJlPr0HO3DxsKTl9I+kZxrLF/ykOuv0bn1uHv20oCfj6LS/8B6+sOxDDd0BWF2ugX6mqFwO4EcB9InJ15xVEZLaI5ItIfmUlp7BNtr/+8FL87xnnAACGhTEx1z/vvRyv3T2ly/JzB2cGfV/BI1/Br24ej3d+dgVe/WEu5n39/A6vO2Ue9jlLP0dTqwt5O8uxqbjae8/RX71zemrfA8ay+e/vCrqt3eX1ePS9ooCvbz9ci8fzdptQNVlVTIGuqmXG1woA7wC4zM86C1U1V1Vzs7PNmao1UcYOCh5aVjR93CBcNLw/AGDckL4h1780JwtXjR3Ypfk9cVj/gO95+KbxyOqTgXumjcHkkQMwY9xgjMn2HMsBvdMBOKfLJS3ATxhH+VA8RB3oItJHRPq2PwbwVQDB7yhAcSMRNHmjiRJ/AdR5ZE44FURSpx10C/D9OuUXGiVWLKNcBgN4x/gB7Q5gqap2vaULpaxIstXsAHJKoLUHulO+X0quqANdVQ8AuMjEWlKOwxqTCeG0Q5oW4LZRzHeKBw5bdKBoLmJiAEUnYKCzyU5xYLvJufzNjBet8UPPwBfHGkzbXjydmZmBQX17oCLILdO6Cr+93L9XepdlQ/p1HCUzIqu3sbzrJF1ZvTMAAJNH9sfK3RU4b0hf7CqPz4RkqaS4yjOC5Xcr9nRY/mXlSb+f1fZlU0ZnYVNxNX5y9Ri8tPaA33XW/WK695hH4tYX/oNth2tR8uTNEb+XUpvtAj1Wv/nmBXjYGFL25LcuDDg74YZfzkB9UxtqGltQ19SKkVm9ceNz64Ju+5pzs5HVJwOjzuyNBSvNnVr14pED8O+fT8PROM1gOHZwX6zaU9Fh2fUTBmPujePwrcnDAAB3TR2F0QP7YNrYgV3eP3F4Pyy9Zwpyc7JQcKgGFw3vjwe/ei5Otbpw3TNru6y/9MdT8NKnB/DpF84c6rqp2DNOvXOY+9p79ERUgb7tcG3UdVFqY5dLJ/815fRNlXtlpAVcb2i/XjhvSF9MHXMmrp8wBN0D/GkNAHdcNgIAcP2EIXj2e5PwwHXnmlewj4GZPXDBsH5x2XZnCoWI4N5rzsagMzwt8m7dBFefmx1wJMsV5wxERvdumDrmTPTKSMPwAb1xziD/QyevOHsgFs3i1EBEkWCgJ0CqdZeaNWwx3gIN+SMi/xjoJgkne5hPkeHxIooMA900gdMn1VroVslJp12ERBQrW50UzfeZ8IjI7j7ZW4GcgX3Qp0ca8ktqvMu/rGxAUVk9MnukYfp5g9DY4kJdUyt6pafB5dO6cLsVbW5FeV0TBmb2QP2pVgz1Gbl0pKYRZ/bpARGg8kRzVCdgKbFsE+hNLa4ON+2NxcDMDFQ1tAAAZo4b5B3dcfHI/th2uBb+7uec1SfD+7h/73TUNrYG3cew/r1QWttkSr2RiuYPhotHDujwfOroM80pBsBXzh+Mj3cdQ++MNDS2uJA7akDoNxGWbjqEpZsOdVk+8+lPvY/nTD8HK3cfw56jJ7qs9+KnX+JwdSPe2HLYO+TVdyjjVb9bjSmjszCgdwZWFB3FF4/fiIzu/KM+ldkm0JvbXKZta+0vpqPNSO2/3HUJiqtOYmBmD/TOSIPL7f/0YFafDGx5+DpkpHVDenfB+Y9+CADYPu+r+K0xA55vB8L5Z52RtEBvF0mPxvUThmDzQzPRr3c6Dh5vNHXishe+fzEamtvQM70bjje0ILsv7zdqlnX7q/yGOQBsPViDvcZrga5f2FRc7Q3xWO97S/Fnm0A387PWO+P0YUlP64ZzB4eelRCA3yDq1yvd7wgRK/YOtw9PDPd4hCujezdkdff8hdM7yzYfyZQQ7HMmCDOkjVV4SiP12ebvJyu0HXx/IJL5w8GGlnMEuTwCQHiBzql+rcM+gZ7CKeWvNEmBNnryK6B4CzVSKKwGeur+aFEn9gn0ZBcQhlQIcXKW0C300Nuwws8Wedgm0Oubgo8qSTXsj6RE2OIznLGzVXsqUNXQ8WTogcoGLN9RhtrGFu+y9r9+P9t/HCXGZGOUmmxzBmqGz1CtaF2Wk2VCJR6XjBqAk81tAV+/7dIR+KDwqGn7i8SFwz3zvXzv0hFJ2T+lLn8/R+2t+B8t3gIAnKUxhdkm0CNx91WjsWi95w7r8fpwvvXTK7yP/f3JOv28QabsJ5r6z+rfyzI/lDPGDcIneyq808nec9VoZPftgSc+2BP6zUQOY5suF0tgN0vM2FVFFBgDPQE4SoCIEsGRgZ6sRh4bl5HzNxyVrXQi/5wZ6AkOBF6YYR7OwEgUmGVPij6+fBe2lFRj+5G6iN+brFBgGJmD4/mTa/XeCtNO6pO5LNlCb2lz45X1xRGH+f/9xgSMG9IXP7h8FH5183j815SRcaqwoznTz8G4IX1x3fjYfwh6pachd9QAzBw3CM/dPsmE6lLbL24YhwlnnYHLRnuGlAqAWycPw7ghffHUdy7EpTmhZ2YcdSanfTXTj/66JdklUACWbKFH04XRPkxv1hU5AIB7po0xs6SgxmRnYsUDV4e9vojnROrgM3rgWL3nwo8/fPci/J9/bseNE4fgmdvsH+Ttxg89A3n3T8OLa770LBDPJGjtx/O7uSOQMzcv6DZuv3Qkfnrt2d71fIdsTv71R6gxpjouefLmLtt666eX49svmjMtM1G8WbKFTmSWUE0DdpORlcQU6CJyg4jsFZH9IjLXrKJC4TBA50nWiWXGOVlJ1IEuImkAXgBwI4DzAdwhIuebVVgwdg90hkhgiT4hyhY6WUksLfTLAOxX1QOq2gLgDQC3mFNWcBwGSInCOCcrieWk6DAAh32eHwEwJbZy/Pvjqn1Ytr3M+9zut8Lqk9EdJ5rb0DM9zbssPc0TLRlpzjztkd7N831npEUeselB3tM7PQ21CDxTZ1qo+Wcd6ivPxD4ZntP89lsTcamJEwD6E0ug+/ukd0laEZkNYDYAjBwZ3TDB7L49MHZwx3tYflkZ3jSev/3mRGT2TM3BPO/87ArcsyQfx0+enqq0d0Ya8u6fhvd3lOFrFw7FkZomVDU046aJQ7GrvB4/u/acJFacPHddPgpVDc2499qzu7z2u29PxNsFpRg2oBcOVzd2mTL2zqmjAACLZuWi1dXxI7r0x1Nx7R/W4IfG6KcVD0zDf/YfR98e3TEmuw8mnHUG7p85FundBE9//IV3nRsWrAtYa6/0NDS1mneP21ST0b1bl59HCq2XTwMtXiTaO/2IyOUA5qvq9cbzXwKAqj4R6D25ubman58f1f6IiJxKRLaqam6o9WL5+30LgLEiMlpEMgDcDmBZDNsjIqIYRN0XoaptIjIHwIcA0gC8qqpFplVGREQRialzWVX/DeDfJtVCREQxcOaQCSIiG2KgExHZBAOdiMgmGOhERDbBQCcisomoLyyKamciJwDsTdgOrW0ggKpkF2EBPE7h4XEKXyoeq1Gqmh1qpURfE783nKudCBCRfB6r0HicwsPjFD4rHyt2uRAR2QQDnYjIJhId6AsTvD8r47EKD49TeHicwmfZY5XQk6JERBQ/7HIhIrKJhAV6sm4obTUiUiIiO0Vkm4hw8ngfIvKqiFSISKHPsiwR+VhE9hlfBySzxlQQ4DjNF5FS43O1TURuSmaNqUBERojIahHZLSJFIvJzY7llP1MJCfRk3lDaoqar6iSrDp2Ko8UAbui0bC6AVao6FsAq47nTLUbX4wQAzxqfq0nGTKlO1wbgQVUdD2AqgPuMXLLsZypRLfSk3VCa7ENV1wKo7rT4FgBLjMdLANya0KJSUIDjRJ2oarmqFhiPTwDYDc+9ki37mUpUoPu7ofSwBO3bahTARyKy1bgfKwU3WFXLAc8PKIBBSa4nlc0RkR0nLGq7AAADuElEQVRGl4xluhESQURyAEwGsAkW/kwlKtDDuqE0AQCuVNWL4emeuk9Erk52QWQLLwI4G8AkAOUAnk5uOalDRDIBvAXgAVWtT3Y9sUhUoB8BMMLn+XAAZQnat6WoapnxtQLAO/B0V1Fgx0RkKAAYXyuSXE9KUtVjqupSVTeAl8HPFQBARNLhCfPXVfVtY7FlP1OJCnTeUDoMItJHRPq2PwbwVQCFwd/leMsAzDIezwLwXhJrSVntAWX4Jvi5gogIgEUAdqvqMz4vWfYzlbALi4xhUgtw+obSv0nIji1ERMbA0yoHPBOnLeVxOk1E/gHgWnhmwzsGYB6AdwG8CWAkgEMAvquqjj4hGOA4XQtPd4sCKAHwk/Z+YqcSkasArAOwE4DbWPwQPP3olvxM8UpRIiKb4JWiREQ2wUAnIrIJBjoRkU0w0ImIbIKBTkRkEwx0IoOIPJTsGohiwWGLRAYRaVDVTD/LBZ6fFbeftxGlDLbQyVJE5F1j4rKi9snLRKRBRH4jIttFZKOIDDaWn2083yIivxaRBmP5UBFZa8wLXigi00TkSQC9jGWvi0iOMU/2nwEUABghIncYc9UXisjvfGpqEJHfGXWtFJHLRGSNiBwQkW8k4TCRQ7GFTpYiIlmqWi0iveCZUuIaAFUAvqGq74vI7wHUq+rjIrIcnjk6/iEi9wL4g6pmisiDAHqq6m+Mufp7q+oJ3xa6MfveAQBXqOpGETkLwEYAlwCoAfARgOdV9V0RUQA3qeoHIvIOgD4AboZn7v8lqjopYQeIHI0tdLKa+0VkOzzhOgLAWAAtAJYbr28FkGM8vhzAP43HS322sQXAj0RkPoCJxlzY/hxU1Y3G40sBrFHVSlVtA/A6gPaZMFsArDAe7wTwqaq2Go9zQJQgDHSyDBG5FsB1AC5X1YsAfA6gJ4BWPf2npgueeXACMm4AcTWAUgB/F5EfBFj1pO/ug2zSd/9uAM3GftyhaiEyEwOdrKQfgBpVbRSRcfDcNiyYjQC+bTy+vX2hiIwCUKGqL8Mz297FxkutxnSq/mwCcI2IDDS6ae4A8GmU3wdRXDDQyUpWAOguIjsAPAZPYAfzAID/FpHNAIYCqDOWXwtgm4h8Dk/gP2csXwhgh4i83nlDxsyEvwSwGsB2AAWqaplpVckZeFKUbEtEegNoUlUVkdsB3KGqvJct2Rb798jOLgHwJ2MceS2A/5Xkeojiii10IiKbYB86EZFNMNCJiGyCgU5EZBMMdCIim2CgExHZBAOdiMgm/j9Kzz9MCHml9QAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x181ae77048>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.plot(mrk421.bin_mid, mrk421.counts)\n",
+    "plt.xlabel(mrk421.bin_unit)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Text(0.5,0,'Angstrom')"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXQAAAEKCAYAAAACS67iAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMS4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvNQv5yAAAIABJREFUeJzt3XmYFdWd//H3l6ZBNgWkWVygQUlAXMC0iruiiVsyks0lozF5NMZERp2feTIkmURmNNEsbskYoxEjmUicJK6RiAtCAEVWQUBAkEVoGrqBZmlo6O38/ri3m17ufutuVZ/X8/D0vXXrVn27uP3p06dOnTLnHCIiUvg65boAERHxhgJdRMQnFOgiIj6hQBcR8QkFuoiITyjQRUR8QoEuIuITCnQREZ9QoIuI+ETneCuY2RHAbKBreP2/OefuMbOhwHNAX2AJcKNzri7Wtvr16+dKS0vTLlpEJEgWL168wzlXEm+9uIEOHALGOedqzKwYmGtmrwH/D3jYOfecmf0OuBl4PNaGSktLWbRoUQK7FBGRZma2KZH14na5uJCa8NPi8D8HjAP+Fl4+BRifQp0iIuKRhPrQzazIzJYClcCbwMfAbudcQ3iVLcCxUd57q5ktMrNFVVVVXtQsIiIRJBTozrlG59xo4DjgTGBkpNWivPdJ51yZc66spCRuF5CIiKQoqVEuzrndwCxgLNDbzJr74I8DtnpbmoiIJCNuoJtZiZn1Dj/uBlwKrAJmAl8Jr3YT8HKmihQRkfgSGeUyCJhiZkWEfgH8xTn3qpl9CDxnZvcB7wOTM1iniIjEETfQnXMfAGMiLF9PqD9dRETygK4UDaimJsdfFm6mobGpZVnVvkNMX7Eth1WJSDoU6AH1l0Wb+f7zHzB57oaWZTdOns9tf1rMgbqGGO8UkXylQA+o6gP1AOw6cHi2hs27DgDQpPuGixQkBbqIiE8o0EVEfEKBLi3U0yJS2BTo0oHlugARSYkCPeDKq2v5xfTVOKf2uUihS+RKUfGxVz+oAODq0REnyxSRAqIWugDg1IMuUvAU6NJCvS4ihU2BLh2YzoqKFCQFekAptEX8R4EuHajrRaQwKdAFgMq9h6itbwTgt7PW5bgaEUmFAl0AmBYevgjw2MyPc1iJiKRKgR5Q7btVNGxRpPAp0AVQv7mIHyjQBdDEXCJ+oEAXEfEJBbqIiE8o0APgsZnrKJ04jbqGpqjr/G3xljbPSydOY8kn1S2Pf/Ti8ozWKCLpU6AHwO9mhYYhHmxobFmWyJWiM1dXtjx+dv4nntclIt5SoIuI+IQCXaLSdC8ihSVuoJvZ8WY208xWmdlKM7szvHySmZWb2dLwvyszX66kQkMSRYIhkTsWNQB3O+eWmFkvYLGZvRl+7WHn3K8yV554SS1uEX+L20J3zlU455aEH+8DVgG6X1meO1jfyLrKGmoONaS8jRmrK6mta4y73rY9B2lojD6CRkSyI6l7ippZKTAGmA+cC0wws68Diwi14qu9LlBSc9PTC5i/YRfdioso6pRa23zl1r2M/Mn0mOvsqa1n7P0zuGHsYO4bf0pK+xERbyR8UtTMegLPA3c55/YCjwMnAKOBCuDBKO+71cwWmdmiqqoqD0qWRMzfsAugZUrcTNl3sB6Amav1fyuSawkFupkVEwrzZ51zLwA457Y75xqdc03A74EzI73XOfekc67MOVdWUlLiVd2SBJeFmbeysQ8RiS2RUS4GTAZWOecearV8UKvVvgis8L488ZJl4L5zmdimiKQmkT70c4EbgeVmtjS87IfA9WY2mtCouI3AtzNSoeQ1tcxF8kfcQHfOzSXyiLd/eF+OZJLCV8TfdKWopEVdLiL5Q4EeIJkMX7X9RXJPgS4i4hMKdBERn1CgB0Amu0PUgy6SPxToAaLwFfE3BbqIiE8o0H3oo+372jw/kMCMiemqb2zip9M+5JG3PuJgfSO/mbE25j1MRcR7Sc22KIXhcw/Pzvo+d9TU8fs5GwCYs3YHizdV0/OIznzz3KFZr0UkqNRCDyiv+tMjDW3fUxuagfFgvVroItmkQA8QXdQp4m8KdBERn1CgB0jrubl0qb6I/yjQRUR8QoEeIK370JuyMJVuk3NMmLqEFeV7WpZV76/jG39YwM6aQxnfv0jQKNADaldNXcb3sXHHfl79oII7/vx+y7L/fW8Ts9ZU8cy7GzO+f5GgUaBLWizCAEjdSEMkNxTo4rlYca6sF8kcBXqAtG5NezUmPdJ2Etm0hsSLeE+BLmmJ1OKOdWckpwGTIhmjQA+onN8LNNf7F/EhTc6VhhXle/j8b+by9t0XMqykZ67LAWBKnNEjt09dwrQPKjzb3+bqAx2Wrausibjugg27eOSttZ7tW0TaUgs9DS+9Xw7AjFWVOa7ksHteWRnzdS/DHGDWmvjfe3Mny7PzN7UsU/tcxHsKdMkY9aqIZJcCPUDy6YSkwl7Ee3ED3cyON7OZZrbKzFaa2Z3h5X3N7E0zWxv+2ifz5Uq+iXRhUbPmETDKbpHsSKSF3gDc7ZwbCYwFbjezk4CJwAzn3HBgRvi5BEyqLe1YvwhEJDVxA905V+GcWxJ+vA9YBRwLXA1MCa82BRifqSLFG+lepdnYdHgDB+sbaWiMfUei+vDrhxqaIt5fdP+hhvQKEpE2kupDN7NSYAwwHxjgnKuAUOgD/b0uTrz1wGur03r/dU/Oa3k84sfTufbJ92Ku/9LSrQCU765l3IOz2ry2vHwPo+55ndeWezvqRiTIEg50M+sJPA/c5Zzbm8T7bjWzRWa2qKqqKpUaxSP/+96m+CvFsHBjdZvnizdVJ9xxsqW6ts3z5eW7AZi9dkdaNYnIYQkFupkVEwrzZ51zL4QXbzezQeHXBwERByQ75550zpU558pKSkq8qFnySYqd6If70PNn5I1IoUtklIsBk4FVzrmHWr30CnBT+PFNwMvel1cY8mk4YNal2DHf/HtAsy+KeCeRS//PBW4ElpvZ0vCyHwIPAH8xs5uBT4CvZqbE/KWx1Km3r3XoRLwXN9Cdc3OJ/vN3ibflFBa1LlPXPDmYjqGId3SlqAeWbd4TfyUfOVjf2PK4fHdtjDXbWrp5d0rvE5HEKNA9MG15BXMDNFrj7r8ua3n8wpLyhN+3aWfHmRkDff5BxGMKdI+U7+4YVn61uN3wxXSoy0XEOwp0SVqTUlgkLynQJWmKc5H8pECXpDkPW+j65SDiHQW6RzR7oIjkmgI9jvnrd7Jya+RhiUG8sGj5lj2ensiMtK1XP9hK5b6D3u1EJCAU6HFc++R7XPXrubkuI2984X/mZvSk6L6D9UyY+j5fn7wgY/sQ8SsFuiTNyzhvPw69KTxt+lZdeCSSNAW6JM3TBrrOiop4RoHulQD1p3s5yiXqPjK+BxH/UaCnoU2uBSiBMvqtBugXo4jXFOiSNE9HuXi3KZHAU6BH4ZzjV6+vaXm+s+YQ97y8IuLNjmOZPHcDCzbs8rq8DtZV1jDmv9/I+H4Aajy8ufPy8tgzVdY3NjHplZXsqDnk2T5F/EqBHkX1gXr+Z+a6luf3vvohU+ZtYvrKbZHfEKWr4N5XP+SaJ+ZFftFDNzw1n+oD9Rnfj9fWVdbEfP2tD7fzzLsbueeVlVmqSKRwKdCjaH/ir9FFXp4v6huT+8uhUDTl+XEXyScK9DQE8UrRrFF+iyRNgZ4gtRCzQ78kRVKnQI/CoiRL1OWZLEZEJAEKdMkr+kNIJHWdc11Avlm9bS83PLWAqd86q83y5uGKs9ZUMnZoX6789RxOPvaoqNsZ+ePp1La6mfKwH0zjlvOHUVsXWnbv+JPTrvUX01ezdXctj1w3Ju1tiUjhU6C389ScDeyoOcTbqyvbLN+6JzRZ1AtLyhkzuA87auqYtaYq6nZahzmERms8OXt9y3MvAv23sz4G4JHrxvjmHGL7Hi3dRFokcepyiaJ9n3i8UYHR+tZFRLJFgZ6geKNcNArGW81HU3eCEklc3EA3s6fNrNLMVrRaNsnMys1safjflZktM3ui5XJjU34Htl9+oSi+RVKXSAv9GeDyCMsfds6NDv/7h7dl5V77HpR8D3S/0FEWSV3cQHfOzQYyP7tUnmv0SQtYRPwrnVEuE8zs68Ai4G7nXLVHNeWlTTsPtDz+8UsrOrzefFK0dOK0rNXkR9v2hG4O7eWMjiJBkepJ0ceBE4DRQAXwYLQVzexWM1tkZouqqqIP8xMBWLNtX65LEClYKQW6c267c67ROdcE/B44M8a6TzrnypxzZSUlJanWKQGlcegiiUsp0M1sUKunXwQ69kEUqOYAKbThcoo9EYnbh25mfwYuAvqZ2RbgHuAiMxtNKEc2At/OYI05kex1QoUV//mr/S+mQvvFKpJLcQPdOXd9hMWTM1BLXtGgltzwy3h6kVwI/JWiFXtqOdh63pVwnuyvS26URZNzLPkk8YE+CzbsYk8Ct4zbvOtAQmPgdxfg7eeaLdy4i526Z6hI2gIf6Gff/zbffXZJh+WPvLU2qe38+u21fOm37ya8/jVPzOO0ODd13rRzP+f/YiaPvPVRzPVeWbY14f3mo6/+bh6fue8tQHPiiKQj8IEOtJ1ZMcU82byr1ptiWtm+N9RqfW/9zpjrrSjf4/m+RaTwKNDbK8AuXD83ajVsUSRxCnQf6OSjRI92UlSjXUTiU6D7QJGPAl1EUqdA94FOAchzdb2IxKdAD5u+ooKmJsf7m3fnupSk/frtdbkuwRNf+/17zP5oR5tl6moRSZzuKRp225+WcO/4k9mwY3+uSwmsdz+OPZpHRGILdAu9/Qm4yr0Hc1RJZNm6avKGsYMBuPWCYVnZn4hkRqADXUTETwId6O0bwPk2jYiumtTJUJFkBDrQJaT5F1k+//rQyVGR+BToeUwzD4pIMgI9yqV9XLaZdTFH5q7dQV1jI01NsGLr4TlaFmwIzUi4pbqWz582iEFHdcthldmxo+YQj4YnSWvuetlzoJ4p8zYy4eIT6dRuAH7zsRs3YkCHbT234BOGD+jJ3LU7mTDuRIqCMHhfAifQgd7eU3M35LoEbpg8P+Lya56Y1/L4paXlTLvjfM/2efN5Q5mzdgeXnTyQJ2av92y76SoLz8DY2qS/r+TF98sZdcyRXDKybXA3H7uND1zV4X0TX1je8vjTA3ty+cmDOqwjUugC3eVSqF0a+w8lN1d7PMNKejL7+xdT0rOrp9vNhObvvb4x9f+7dN4rks8CHegiIn6iQC9AGs4oIpEEOtD1h3fh6DhsUf97Iu0FOtCl8OiPE5HoAj3KpVDOiVbu63gD5T/O25j1OnJp2vIKpk2cFvG1lVv38MvX1yS8rQL5bxdJWqADvVBs2nmgw7KfvLzSk21fU3acJ9vJpf94/gNWlO/NdRkiOacul4ArG9I31yWkKPW+F/XaiF8FOtALdeInBRK07jgplK4zkUyLG+hm9rSZVZrZilbL+prZm2a2Nvy1T2bLlEwp1F9q6QjedyxBkUgL/Rng8nbLJgIznHPDgRnh5wVHLTsR8ZO4ge6cmw3sarf4amBK+PEUYLzHdUksHva5+OGXWrLfg7qsxK9SHeUywDlXAeCcqzCz/h7WlFGl4aFv6392JfPWF+Y9LNdX6b6nt/1pCeNG9GdvbT0fViQ3wuWRtz7iC6cdk6HKRHIn48MWzexW4FaAwYMHZ3p3CatrbGLq/E9yXUbOFXID/e3VlSm972P9QhSfSnWUy3YzGwQQ/hr1J8s596Rzrsw5V1ZSUpLi7kREJJ5UA/0V4Kbw45uAl70pJ3uc80f/cbp0DET8I5Fhi38G5gGfNrMtZnYz8ADwWTNbC3w2/LyghIbrKc1ExD/i9qE7566P8tIlHtciIiJp8P2Voo1Njr0H6zssr9p3iL0Hvb3zTyrqGpo4UJe7OoJwYVF9Y1NC6x2sb4x7X9n9hxoS3p5Itvk+0O+b9iGnTnqD2rq2P6gX/nIWCza0H16ffRf+ciYn/eT1XJfha8N/9FpC65066Q1G3RP7/2LUPa/ztd+/50VZIp7zfaC/vHQrAPtz2AqOpWLPwZzuv+ONI0L+PuE8Xrr93CxXk1t1jU00NsX/i2XhxuosVCOSPN9Pn9scVxrNkbjj+nTjlOOOynUZIpIk37fQdYcbEQkK3wd6syCc/BORYAtAoIeb6MpzEfG5AAT6YauSnMQp21Zvy+/6CkVVq3uwbt8b+aTzusqalsef7DzA1t21Lc/XbNvHpp372ZbCCWvnXF6MnpJgClSgX/HonFyXENPlj2S/vtbnGHp3Lwbgy6cX9n1Gz33g7ZbHZ/1sRsR1Ln3ony2PL/jlTM5p9Z7LHpnNhb+cxdj7I783lj+9t4lrnpjH6yu3Jf1ekXT5PtAtgD0uC390aUrv63VEMWvuu5y7Lh3ucUXZVZfDC3+aZ3Isr66Ns6aI9wIzbDFIjuyW+n9r185FHlYiItnk+xZ6syCNQ492sZCI+JvvA/1wl0uAEj0Jin4R//B/oAcwspK5mEoXXon4h+8DfVt42NrM1VU5rkSyqanJ8ZOXV8RcZ8LUJVTvr4u5Tnl4OOP0FdsY+ePpHV6f9MpKXl5annqhIh7yfaA3++GLy3NdQtYUmTHgyK50SqD1ff5wb24LeO6JR3uyHa+8uryCP87bFHudDyoYc++bMdcZ/9g7ANz2p8XUtptad0X5Hp55dyN3Prc0vWJFPBKYQA+STp2M+T+8lPX3X8VNZw+Jue4xvbulvJ97rx7V8vjZW8Zy5SkDU96W12o8muu+9UVK7cWbO10k2xTokrL2p5nz6XyFToJLECnQxZeCNExVpJkCXbyTPw10kUBSoItn8inP1UCXIPJloP/fwk+YvqKCX89Ym+tSEtaUwK3PJHEry/d4tq3SidM6LLv7L8v4yu/mtTyf9MrKNq+/v3l3QX3+xB98OZfLfzxfeEMUV27NzNS5d1wynGVb9tC3Rxd6HdG55R6rmdC/1xEJr3vMUUewNYP3U31u4eaMbRvg+SVb2jx/5t2NTPqXw6N+/r4sdJzvuKSwJzqTwuLLFnohakrzLN4TN34m4vKje3blpdvP5elvnMGj141JeftnDe0bd51krjo9umfXlGsRkcgU6Hki3ztcvK5PwwpFvJdWl4uZbQT2AY1Ag3OuzIuigsgV4Di7AixZxNe86EO/2Dm3w4PtSBoyPsIkgfDOp1EuIkGkLpc8EbTGrlr3It5LN9Ad8IaZLTazW70oKKi+9Nt3c11CbAk0v4Oe0aUTp/HMuxvbLHtv/U5G/ng6m3cd4Non5nHJg7MonTiNhRsP30h6XHjZM+9siLn9Kx6dwx/nbYz6+tWPvcNTc9an8R1IoUs30M91zp0OXAHcbmYXtF/BzG41s0VmtqiqSlPY5tofvnEG/zbuRACOTWBirr/edjZ/uvmsDss/NaBnzPct+fFn+c+rRvLid8/h6W+Ucc8XTmrzelDmYZ8w9X1q6xuZtryC+Rt2tdxz9D9fPDy17/rwskl//zDmtlZV7OUnL6+M+vqyzbu5b9oqD6qWQpVWoDvntoa/VgIvAmdGWOdJ51yZc66spMSbqVqzZXj/2KFViC4e0Z/TjusNwIiBveKuf0ZpX84b3q9D8/uUY3tHfc+PrhxJ3x5duOX8YYwZ3IdxIwYwrCR0LPt0LwaC0+VSFOUnTKN8JBNSDnQz62FmvZofA58DYt9RQDLGkmjyphIlkQKo/cicRCpIpk4/6BTl+w3KLzTJrnRGuQwAXgz/gHYGpjrnOt7SRfJWMtnqdQAFJdCaAz0o36/kVsqB7pxbD5zmYS15J2CNyawI2iEtinLbKOW7ZIKGLQZQKhcxKYBSEzXQ1WSXDPDd5FyRZsZL1chBR/LR9hrPtpdJR/fsQv9eXamMccu0jhJvL/fuVtxh2cCj2o6SOb5v9/DyjpN09e3eBYAxg3vz1qpKPj2wFx9WZGZCsnyyYUdoBMvPp69us/zjqv0RP6vNy84a2pf5G3bx7QuG8cTs9RHXmfP9i1uOeTLGP/YOSzfvZuMDVyX9Xslvvgv0dP30iyfzo/CQsge+dGrU2Qnn/WAce2sbqD5Qx57aegb37c4Vj86Jue0LP1VC3x5dGHJ0dx55y9upVU8f3Id/3Hk+2zI0g+HwAb2YsbqyzbLLRg1g4hUj+NKYYwG4cewQhvbrwfnD+3V4/ynHHcXUW86irLQvSz6p5rTjenP35z7FwfpGLn1odof1p37rLJ7453r++VEwh7rO3xAap94+zFtbs21fSoG+dPPulOuS/KYul3b+9azDN1Xu1qUo6nqDjurGpwf2Yuywo7ls1EA6R/nTGuD6M48H4LJRA3n42tHcdemnvCu4lX49u3LysUdlZNvtORxmxm0XnkD/I0Mt8k6djAs+VRJ1JMs5J/ajS+dOjB12NN26FHFcn+6c2D/y0MlzTujH5Js0NZBIMhToWZBv3aVeDVvMtGhD/kQkMgW6RxLJHuVTcnS8RJKjQPdM9PTJtxZ6oeRk0C5CEkmXr06KLmo14ZGI3729ppLSfj3o0bWIRRurW5Z/XFXDyq176dm1iIs/3Z8DdY3sqa2nW3ERja1aF01NjoYmR8WeWvr17Mreg/UMajVyaUv1AY7u0RUzqNp3KKUTsJJdvgn02rrGNjftTUe/nl3YUVMHwCUj+reM7jh9cG+Wbt5NpPs59+3RpeVx7+7F7D5QH3Mfx/buRvnuWk/qTVYqfzCcPrhPm+djhx7tTTHAZ08awJsfbqd7lyIO1DVSNqRP/DcJU+d/wtT5n3RYfsmD/2x5POHiE3lr1XZWb9vXYb3H//kxm3cd4LmFm1uGvLYeynjez2dy1tC+9Onehekrt/HRfVfQpbP+qM9nvgn0Qw2Nnm1r9vcvpiGc2r+78TNs2LGffj270r1LEY1NkU8P9u3RhYU/upQuRZ0o7myc9JPXAVh2z+f4WXgGvNYdCCcdc2TOAr1ZMj0al40ayIIfXsJR3YvZtPOApxOXPfa106k51MARxZ3YWVNHSS/db9Qrc9btiBjmAIs3VbMm/Fq06xfmb9jVEuLp3vdWMs83ge7lZ617l8OHpbioE58aEH9WQiBiEB3VrTjiCJFC7B1uHp6Y6PFIVJfOnejbOfQXTve+vvlI5oVYnzMjwZAOr6JTGvnPN38/FULbofUPRC5/ONTQCo4Yl0cAiQW6pvotHP4J9DxOqUilWR600XNfgWRavJFCCTXQ8/dHS9rxT6DnuoAE5EOIS7DEb6HH30Yh/GxJiG8CfW9t7FEl+Ub9kZINC1sNZ2xvxupKdtS0PRm6vqqGVz/Yyu4DdS3Lmv/6fXfdTjaGJxuT/OSbM1DjWg3VStWZpX09qCTkM0P6sP9QQ9TXrznjeF5bsc2z/SXj1ONC871ce8bxOdm/5K9IP0fNrfhvPrMQQLM05jHfBHoybj5vKJPnhu6wnqkP5/PfOaflcaQ/WS/+dH9P9pNK/cf07lYwP5TjRvTn7dWVLdPJ3nLeUEp6deX+11bHf7NIwPimy6UgqJslbeqqEolOgZ4FGiUgItkQyEDPVSNPjcvkRRqOqla6SGTBDPQsB4IuzPCOZmAUia5gT4re9+qHLNy4i2Vb9iT93lyFgsLIGxrPn1sz11R6dlJfvFWQLfS6hiaemrsh6TD/r38ZxYiBvfj62UP4z6tG8q9nDc5QhW1NuPhERgzsxaUj0/8h6FZcRNmQPlwyoj+PXjfag+ry2/cvH8GoY47kzKGhIaUGjB9zLCMG9uKXXzmVM0rjz8w45GhN++qlb/5hYa5LkCgKsoWeShdG8zC9m84pBeCW84d5WVJMw0p6Mv2uCxJe3yx0InXAkV3Zvjd04cevvnoa3/vrMq44ZSAPXeP/IG82ctCRTLvjfB6f9XFogYUmQWs+nl8tO57SidNibuO6MwbznYtOaFmv9ZDNMf/9BtXhqY43PnBVh209/52z+fLj3kzLLJJpBdlCF/FKvKaBusmkkKQV6GZ2uZmtMbN1ZjbRq6Li0TDA4MnViWXFuRSSlAPdzIqAx4ArgJOA683sJK8Ki8Xvga4QiS7bJ0TVQpdCkk4L/UxgnXNuvXOuDngOuNqbsmLTMEDJFsW5FJJ0TooeC2xu9XwLcFZ65UT2mxlreWXZ1pbnfr8VVo8undl3qIEjiotalhUXhaKlS1EwT3sUdwp9312Kko/Y4hjv6V5cxG6iz9RZFG/+2YD67EPpT4YXND/70imc4eEEgJGkE+iRPukdktbMbgVuBRg8OLVhgiW9ujJ8QNt7WH5cldg0nj/74in0PCI/B/O8+N1zuGXKInbuPzxVafcuRUy743z+/sFWPn/qILZU17Kj5hBXnjKIDyv28t2LTsxhxblz49lD2FFziNsuOqHDaz//8im8sKScY/t0Y/OuAx2mjL1h7BAAJt9URn1j24/o1G+N5aJfzeIb4dFP0+86n3fW7aRX184MK+nBqGOO5I5LhlPcyXjwzY9a1rn8kTlRa+1WXERtvXf3uM03XTp36vDzKPF1a9VAyxRL9U4/ZnY2MMk5d1n4+Q8AnHP3R3tPWVmZW7RoUUr7ExEJKjNb7Jwri7deOn+/LwSGm9lQM+sCXAe8ksb2REQkDSn3RTjnGsxsAvA6UAQ87Zxb6VllIiKSlLQ6l51z/wD+4VEtIiKShmAOmRAR8SEFuoiITyjQRUR8QoEuIuITCnQREZ9I+cKilHZmtg9Yk7UdFrZ+wI5cF1EAdJwSo+OUuHw8VkOccyXxVsr2NfFrErnaScDMFulYxafjlBgdp8QV8rFSl4uIiE8o0EVEfCLbgf5klvdXyHSsEqPjlBgdp8QV7LHK6klRERHJHHW5iIj4RNYCPVc3lC40ZrbRzJab2VIz0+TxrZjZ02ZWaWYrWi3ra2Zvmtna8Nc+uawxH0Q5TpPMrDz8uVpqZlfmssZ8YGbHm9lMM1tlZivN7M7w8oL9TGUl0HN5Q+kCdbFzbnShDp3KoGeAy9stmwjMcM4NB2aEnwfdM3Q8TgAPhz9Xo8MzpQZdA3C3c24kMBa4PZxLBfuZylYLPWc3lBb/cM7NBna1W3w1MCX8eAowPqtF5aEox0nacc5VOOeWhB/vA1YRuldywX6mshXokW4ofWyW9l1oHPCGmS0O349VYhvgnKuA0A99ZhFkAAAD1ElEQVQo0D/H9eSzCWb2QbhLpmC6EbLBzEqBMcB8Cvgzla1AT+iG0gLAuc650wl1T91uZhfkuiDxhceBE4DRQAXwYG7LyR9m1hN4HrjLObc31/WkI1uBvgU4vtXz44CtWdp3QXHObQ1/rQReJNRdJdFtN7NBAOGvlTmuJy8557Y75xqdc03A79HnCgAzKyYU5s86514ILy7Yz1S2Al03lE6AmfUws17Nj4HPAStivyvwXgFuCj++CXg5h7XkreaACvsi+lxhZgZMBlY55x5q9VLBfqaydmFReJjUIxy+ofRPs7LjAmJmwwi1yiE0cdpUHafDzOzPwEWEZsPbDtwDvAT8BRgMfAJ81TkX6BOCUY7TRYS6WxywEfh2cz9xUJnZecAcYDnQFF78Q0L96AX5mdKVoiIiPqErRUVEfEKBLiLiEwp0ERGfUKCLiPiEAl1ExCcU6FJQzOyLZubMbITH2y01s695uU2RbFOgS6G5HphL6OI0L5UCEQPdzLJ9M3WRlGgcuhSM8Jwba4CLgVeccyPM7CJgErADOBlYDNzgnHPhi9keCr+2BBjmnPu8mV0IPBrerAMuAN4ERgIbCM2wVw1cBRwB9AAuAX5BaI4dB9znnPu/8P7/i9AFPKOBFwhdqHIn0A0Y75z7OEOHRKQNtTykkIwHpjvnPjKzXWZ2enj5GGAUofmB3gHODd8c5AngAufchvDVk82+B9zunHsn/EviIKE5r7/nnPs8gJl9AzgbONU5t8vMvkwosE8jdAXmQjObHd7eaYR+GewC1gNPOefODN8w4d+AuzJyNETaUZeLFJLrCc2lT/jr9eHHC5xzW8ITTy0l1H0yAljvnNsQXqd1oL8DPGRmdwC9nXMNUfb3ZqtLvs8D/hye4Go78E/gjPBrC8Nzax8CPgbeCC9fHq5FJCvUQpeCYGZHA+OAk83MEZoTyAH/AA61WrWR0Oc60pTNADjnHjCzacCVwHtmdmmUVfe3LiFGea3339TqeRP6GZMsUgtdCsVXgD8654Y450qdc8cT6u8+L8r6q4Fh4RsXAFzb/IKZneCcW+6c+zmwiFBrfh/QK8b+ZwPXmlmRmZUQ6ndfkM43JOI1BboUius5PBNls+eJMjLFOVcLfBeYbmZzCZ203BN++S4zW2Fmy4Ba4DXgA6DBzJaZ2b9H2OSL4XWWAW8D33fObUvzexLxlEa5iG+ZWU/nXE143uvHgLXOuYdzXZdIpqiFLn72LTNbCqwEjiI06kXEt9RCFxHxCbXQRUR8QoEuIuITCnQREZ9QoIuI+IQCXUTEJxToIiI+8f8ByYo/wnEFaAEAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x181b73d6d8>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.plot(mrk421.spectral_axis, mrk421.flux)\n",
+    "plt.xlabel(mrk421.spectral_axis.unit)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "AttributeError",
+     "evalue": "can't set attribute",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-7-604e933ff444>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mmrk421\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_setbins_to_keV\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m/anaconda3/envs/pyxsis-dev/lib/python3.6/site-packages/pyxsis-0.0-py3.6.egg/pyxsis/xspectrum.py\u001b[0m in \u001b[0;36m_setbins_to_keV\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    182\u001b[0m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mbin_lo\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mnew_blo\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    183\u001b[0m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mbin_hi\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mnew_bhi\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 184\u001b[0;31m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mflux\u001b[0m   \u001b[0;34m=\u001b[0m \u001b[0mnew_cts\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    185\u001b[0m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mbin_unit\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0msi\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mkeV\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    186\u001b[0m         \u001b[0;32mreturn\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mAttributeError\u001b[0m: can't set attribute"
+     ]
+    }
+   ],
+   "source": [
+    "mrk421._setbins_to_keV()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/pyxsis/binspectrum.py
+++ b/pyxsis/binspectrum.py
@@ -113,11 +113,15 @@ class XBinSpectrum(XraySpectrum1D):
 
         if subtract_bkg and (self.bkg is not None):
             blo, bhi, bcts, bcts_err = self.binned_bkg(use_backscale=use_backscale)
-            new_counts = counts - bcts
-            new_error  = np.sqrt(cts_err**2 + bcts_err**2)
-            return blo, bhi, new_counts, new_error
+            counts -= bcts
+            cts_err = np.sqrt(cts_err**2 + bcts_err**2)
+
+        if bin_unit is None:
+            return bin_lo, bin_hi, counts, counts_err
         else:
-            return bin_lo, bin_hi, counts, cts_err
+            return bin_lo.to(u.Unit(bin_unit), equivalencies=u.spectral()), \
+                   bin_hi.to(u.Unit(bin_unit), equivalencies=u.spectral()), \
+                   counts, counts_err
 
     def _parse_binning(self):
         ## Returns the number of counts in each bin for a binned spectrum
@@ -139,12 +143,7 @@ class XBinSpectrum(XraySpectrum1D):
         result *= u.ct
         result_err = np.sqrt(result.value) * u.ct
 
-        if bin_unit is None:
-            return new_bin_lo, new_bin_hi, result, result_err
-        else:
-            return new_bin_lo.to(u.Unit(bin_unit), equivalencies=u.spectral()), \
-                   new_bin_hi.to(u.Unit(bin_unit), equivalencies=u.spectral()), \
-                   result, result_err
+        return new_bin_lo, new_bin_hi, result, result_err
 
     def binned_bkg(self, bin_unit=None, use_backscale=True):
         """

--- a/pyxsis/binspectrum.py
+++ b/pyxsis/binspectrum.py
@@ -117,11 +117,11 @@ class XBinSpectrum(XraySpectrum1D):
             cts_err = np.sqrt(cts_err**2 + bcts_err**2)
 
         if bin_unit is None:
-            return bin_lo, bin_hi, counts, counts_err
+            return bin_lo, bin_hi, counts, cts_err
         else:
             return bin_lo.to(u.Unit(bin_unit), equivalencies=u.spectral()), \
                    bin_hi.to(u.Unit(bin_unit), equivalencies=u.spectral()), \
-                   counts, counts_err
+                   counts, cts_err
 
     def _parse_binning(self):
         ## Returns the number of counts in each bin for a binned spectrum

--- a/pyxsis/plot.py
+++ b/pyxsis/plot.py
@@ -10,13 +10,13 @@ def plot_counts(ax, spectrum, xunit='keV', perbin=True, rate=False, \
                 plot_bkg=False, subtract_bkg=True, use_backscale=True, **kwargs):
 
     if plot_bkg:
-        lo, hi, cts, cts_err = spectrum.binned_bkg(use_backscale=use_backscale)
+        lo, hi, cts, cts_err = spectrum.binned_bkg(bin_unit=xunit, 
+                                                   use_backscale=use_backscale)
     else:
-        lo, hi, cts, cts_err = spectrum.binned_counts(subtract_bkg=subtract_bkg, use_backscale=use_backscale)
-
-    xlo = lo.to(u.Unit(xunit), equivalencies=u.spectral())
-    xhi = hi.to(u.Unit(xunit), equivalencies=u.spectral())
-    mid = 0.5 * (xlo + xhi)
+        lo, hi, cts, cts_err = spectrum.binned_counts(bin_unit=xunit, 
+                                                      subtract_bkg=subtract_bkg, 
+                                                      use_backscale=use_backscale)
+    mid = 0.5 * (lo + hi)
 
     if rate:
         exp = spectrum.exposure
@@ -26,7 +26,7 @@ def plot_counts(ax, spectrum, xunit='keV', perbin=True, rate=False, \
     if perbin:
         dbin   = 1.0
     else:
-        dbin   = np.abs(xhi - xlo)
+        dbin   = np.abs(hi - lo)
 
     y    = cts/exp/dbin
     yerr = cts_err/exp/dbin
@@ -55,11 +55,11 @@ def plot_unfold(ax, spectrum, xunit='keV', perbin=False, \
         return np.array(result)
 
     # Get the binned counts
-    lo, hi, cts, cts_err = spectrum.binned_counts(subtract_bkg=subtract_bkg, use_backscale=use_backscale)
+    lo, hi, cts, cts_err = spectrum.binned_counts(bin_unit=xunit,
+                                                  subtract_bkg=subtract_bkg, 
+                                                  use_backscale=use_backscale)
 
-    xlo = lo.to(u.Unit(xunit), equivalencies=u.spectral())
-    xhi = hi.to(u.Unit(xunit), equivalencies=u.spectral())
-    mid = 0.5 * (xlo + xhi)
+    mid = 0.5 * (lo + hi)
 
     # Get the binned effective area
     if all(spectrum.binning == 0):
@@ -77,7 +77,7 @@ def plot_unfold(ax, spectrum, xunit='keV', perbin=False, \
     if perbin:
         dbin   = 1.0
     else:
-        dbin   = np.abs(xhi - xlo)[ii]
+        dbin   = np.abs(hi - lo)[ii]
 
     # plot values
     x = mid[ii]


### PR DESCRIPTION
Streamlined `binned_counts` method to allow for `bin_unit` keyword. Returns bin_lo and bin_hi in desired Astropy unit.